### PR TITLE
Clarify README.md example security constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ access:
 
   #write and delete is given to owners outbox
   - location: users/$userid/outbox/
-    write:    true
+    write:    $userid === auth.username
 
   #owners can read everything in their inbox and outbox
   - location: users/$userid/


### PR DESCRIPTION
Old version of final README.md example allowed for anyone to write/delete from any outbox. New version requires (1) logged in user, (2) users writing to their own outbox.
